### PR TITLE
Failing test for: react class maximum call stack size exceeded 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for dets
 
+## 0.1.5
+
+- Added support for extends and implements in classes
+
 ## 0.1.4
 
 - Fixed issue with exported class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.1.4
 
 - Fixed issue with exported class
+- Improved treatment of default generics
 
 ## 0.1.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for dets
 
+## 0.1.4
+
+- Fixed issue with exported class
+
 ## 0.1.3
 
 - Support constructor calls

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dets",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A TypeScript declaration file bundler.",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dets",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A TypeScript declaration file bundler.",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/input/visit.ts
+++ b/src/input/visit.ts
@@ -183,10 +183,21 @@ function getIndexType(
   };
 }
 
-function normalizeTypeParameters(context: DeclVisitorContext, type: Type, decl: Type, types: Array<TypeModel>, refName: string) {
+function normalizeTypeParameters(
+  context: DeclVisitorContext,
+  type: Type,
+  decl: Type,
+  types: Array<TypeModel>,
+  refName: string,
+) {
   const maxTypes = (context.refs[refName] as any)?.types?.length ?? Number.MAX_SAFE_INTEGER;
   const typeParameterIds = decl?.typeParameters?.map(t => getDefaultTypeId(context, t)) ?? [];
-  const typeArgumentIds = type.aliasTypeArguments?.map(t => t.id) ?? [];
+  const typeArgumentIds = type.aliasTypeArguments?.map(t => t.id) ?? (type as any).typeArguments?.map(t => t.id) ?? [];
+
+  // omit types that are not listed on the original type parameters
+  while (types.length > maxTypes) {
+    types.pop();
+  }
 
   for (let i = typeParameterIds.length; i--; ) {
     const id = typeParameterIds[i];
@@ -195,11 +206,6 @@ function normalizeTypeParameters(context: DeclVisitorContext, type: Type, decl: 
       break;
     }
 
-    types.pop();
-  }
-
-  // omit types that are not listed on the original type parameters
-  while (types.length > maxTypes) {
     types.pop();
   }
 

--- a/src/input/visit.ts
+++ b/src/input/visit.ts
@@ -183,7 +183,8 @@ function getIndexType(
   };
 }
 
-function normalizeTypeParameters(context: DeclVisitorContext, type: Type, decl: Type, types: Array<TypeModel>) {
+function normalizeTypeParameters(context: DeclVisitorContext, type: Type, decl: Type, types: Array<TypeModel>, refName: string) {
+  const maxTypes = (context.refs[refName] as any)?.types?.length ?? Number.MAX_SAFE_INTEGER;
   const typeParameterIds = decl?.typeParameters?.map(t => getDefaultTypeId(context, t)) ?? [];
   const typeArgumentIds = type.aliasTypeArguments?.map(t => t.id) ?? [];
 
@@ -194,6 +195,11 @@ function normalizeTypeParameters(context: DeclVisitorContext, type: Type, decl: 
       break;
     }
 
+    types.pop();
+  }
+
+  // omit types that are not listed on the original type parameters
+  while (types.length > maxTypes) {
     types.pop();
   }
 
@@ -363,7 +369,7 @@ function makeAliasRef(context: DeclVisitorContext, type: Type, name: string): Ty
 
   return {
     kind: 'ref',
-    types: normalizeTypeParameters(context, type, decl, types),
+    types: normalizeTypeParameters(context, type, decl, types, name),
     refName: name,
   };
 }
@@ -399,7 +405,7 @@ function includeRef(context: DeclVisitorContext, type: Type, refName: string, ex
 
   return {
     kind: 'ref',
-    types: normalizeTypeParameters(context, type, decl, types),
+    types: normalizeTypeParameters(context, type, decl, types, refName),
     refName,
     external,
   };

--- a/src/output/stringify.ts
+++ b/src/output/stringify.ts
@@ -119,7 +119,10 @@ export function stringifyEnum(values: Array<TypeModel>) {
 }
 
 export function stringifyExtends(type: WithTypeExtends) {
-  return type.extends.length > 0 ? ` extends ${type.extends.map(stringifyNode).join(', ')}` : '';
+  const { extends: es, implements: is } = type;
+  const e = es.length ? ` extends ${es.map(stringifyNode).join(', ')}` : '';
+  const i = is.length ? ` implements ${is.map(stringifyNode).join(', ')}` : '';
+  return e + i;
 }
 
 export function stringifyTypeArgs(type: WithTypeArgs) {

--- a/src/types/helper.ts
+++ b/src/types/helper.ts
@@ -11,4 +11,5 @@ export interface WithTypeComments {
 
 export interface WithTypeExtends {
   readonly extends: Array<TypeModelRef>;
+  readonly implements: Array<TypeModelRef>;
 }

--- a/tests/assets/class4.ts
+++ b/tests/assets/class4.ts
@@ -1,0 +1,7 @@
+export class OtherClass<P, S = {}> {}
+
+export class SomeClass extends OtherClass<{}> {
+  public constructor() {
+      super();
+  }
+}

--- a/tests/assets/class5.ts
+++ b/tests/assets/class5.ts
@@ -1,0 +1,9 @@
+export class OtherClass<P, S = {}> {}
+
+export interface OtherInterface<P> {}
+
+export class SomeClass extends OtherClass<{}> implements OtherInterface<{}> {
+  public constructor() {
+    super();
+  }
+}

--- a/tests/assets/class6.tsx
+++ b/tests/assets/class6.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+export class SomeClass extends React.Component<{}> {
+  public constructor(props: {}) {
+      super(props);
+  }
+
+  public render() {
+    return <div/>;
+  }
+}

--- a/tests/classes.test.ts
+++ b/tests/classes.test.ts
@@ -59,3 +59,13 @@ test('should be able to handle class with implemented interface', () => {
   }
 }`);
 });
+
+test('should be able to handle react classes', () => {
+  const result = runTestFor('class6.tsx');
+  expect(result).toBe(`declare module "test" {
+  export class SomeClass extends React.Component<{}> {
+    constructor(props: {});
+    render(): JSX.Element;
+  }
+}`);
+});

--- a/tests/classes.test.ts
+++ b/tests/classes.test.ts
@@ -46,3 +46,16 @@ test('should be able to handle exported generic classes with implicit parameters
   }
 }`);
 });
+
+test('should be able to handle class with implemented interface', () => {
+  const result = runTestFor('class5.ts');
+  expect(result).toBe(`declare module "test" {
+  export class OtherClass<P, S = {}> {}
+
+  export interface OtherInterface<P> {}
+
+  export class SomeClass extends OtherClass<{}> implements OtherInterface<{}> {
+    constructor();
+  }
+}`);
+});

--- a/tests/classes.test.ts
+++ b/tests/classes.test.ts
@@ -1,6 +1,6 @@
 import { runTestFor } from './helper';
 
-test('should be able to handle exported classes', () => {
+test('should be able to handle exported classes with constructor', () => {
   const result = runTestFor('class1.ts');
   expect(result).toBe(`declare module "test" {
   export class SomeClass {
@@ -11,7 +11,7 @@ test('should be able to handle exported classes', () => {
 }`);
 });
 
-test('should be able to handle exported classes', () => {
+test('should be able to handle exported classes with differnet modifiers', () => {
   const result = runTestFor('class2.ts');
   expect(result).toBe(`declare module "test" {
   export class SomeClass {
@@ -25,12 +25,23 @@ test('should be able to handle exported classes', () => {
 }`);
 });
 
-test.only('should be able to handle exported generic classes', () => {
+test('should be able to handle exported generic classes with explicit parameters', () => {
   const result = runTestFor('class3.ts');
   expect(result).toBe(`declare module "test" {
   export class OtherClass<P, S> {}
 
   export class SomeClass extends OtherClass<{}, {}> {
+    constructor();
+  }
+}`);
+});
+
+test('should be able to handle exported generic classes with implicit parameters', () => {
+  const result = runTestFor('class4.ts');
+  expect(result).toBe(`declare module "test" {
+  export class OtherClass<P, S = {}> {}
+
+  export class SomeClass extends OtherClass<{}> {
     constructor();
   }
 }`);

--- a/tests/functions.test.ts
+++ b/tests/functions.test.ts
@@ -26,6 +26,6 @@ test('should handle simple generics and ignore internals', () => {
 test('should handle generator functions', () => {
   const result = runTestFor('function3.ts');
   expect(result).toBe(`declare module "test" {
-  export function myGenerator(): Generator<string, string, unknown>;
+  export function myGenerator(): Generator<string, string>;
 }`);
 });

--- a/tests/imports.test.ts
+++ b/tests/imports.test.ts
@@ -81,7 +81,7 @@ test('should handle jsx from externals (react)', () => {
   expect(result).toBe(`import * as React from 'react';
 
 declare module "test" {
-  export const MyComponent: React.FunctionComponent<{}>;
+  export const MyComponent: React.FunctionComponent;
 }`);
 });
 

--- a/tests/piral.test.ts
+++ b/tests/piral.test.ts
@@ -43,7 +43,7 @@ declare module "test" {
      * The route needs to be unique and can contain params.
      * Params are following the path-to-regexp notation, e.g., :id for an id parameter.
      */
-    registerPage(route: string, Component: AnyComponent<PageComponentProps<any, any>>): void;
+    registerPage(route: string, Component: AnyComponent<PageComponentProps>): void;
     /**
      * Unregisters the page identified by the given route.
      */
@@ -61,7 +61,7 @@ declare module "test" {
     /**
      * React component for displaying extensions for a given name.
      */
-    Extension: React.ComponentType<ExtensionSlotProps<any>>;
+    Extension: React.ComponentType<ExtensionSlotProps>;
     /**
      * Renders an extension in a plain DOM component.
      */
@@ -83,7 +83,7 @@ declare module "test" {
 
   export type DataStoreTarget = "memory" | "local" | "remote";
 
-  export type AnyComponent<T> = React.ComponentClass<T, any> | React.FunctionComponent<T> | HtmlComponent<T>;
+  export type AnyComponent<T> = React.ComponentClass<T> | React.FunctionComponent<T> | HtmlComponent<T>;
 
   export interface HtmlComponent<TProps> {
     /**
@@ -112,7 +112,7 @@ declare module "test" {
   }
 
   export interface ComponentContext {
-    router: ReactRouter.RouteComponentProps<{}, ReactRouter.StaticContext, {}>;
+    router: ReactRouter.RouteComponentProps;
   }
 
   export interface PageComponentProps<T = any, S = any> extends RouteBaseProps<T, S> {}


### PR DESCRIPTION
When running the test, I get:

```
    RangeError: Maximum call stack size exceeded
        at String.indexOf (<anonymous>)

      17 | export function getLibName(fileName: string) {
      18 |   if (fileName) {
    > 19 |     if (fileName.indexOf(typesRoot) !== -1) {
         |                  ^
      20 |       const start = fileName.lastIndexOf(typesRoot) + typesRoot.length;
      21 |       const name = fileName
      22 |         .substr(start)

      at getLibName (src/helpers/identifiers.ts:19:18)
      at Object.getLib (src/helpers/identifiers.ts:48:19)
      at includeExternal (src/input/visit.ts:230:15)
      at getTypeModel (src/input/visit.ts:96:17)
      at getParameterType (src/input/visit.ts:111:12)
      at src/input/visit.ts:132:14
          at Array.map (<anonymous>)
      at getFunctionType (src/input/visit.ts:127:38)
      at src/input/visit.ts:737:81
```