### PR TITLE
Added support for scoped packages with a period on the right side

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "dets",
-  "version": "0.16.0",
+  "version": "0.16.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dets",
-      "version": "0.16.0",
+      "version": "0.16.4",
       "license": "MIT",
       "bin": {
         "dets": "dist/cli.js"
       },
       "devDependencies": {
+        "@jdeurt/math.ts": "^2.0.0",
         "@types/glob": "^7.2.0",
         "@types/jest": "^28",
         "@types/node": "14.11.2",
@@ -1068,6 +1069,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@jdeurt/math.ts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@jdeurt/math.ts/-/math.ts-2.0.0.tgz",
+      "integrity": "sha512-x/KN3To04MCVV6BDWQM+HV/T5L6NbufZ6V8bH8mSHdlRkDjAPWNCFzsKc9ODTHOH/ajwYENbyxhKsfYC7n3koQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@jest/console": {
       "version": "28.1.3",
@@ -5363,6 +5371,12 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true
+    },
+    "@jdeurt/math.ts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@jdeurt/math.ts/-/math.ts-2.0.0.tgz",
+      "integrity": "sha512-x/KN3To04MCVV6BDWQM+HV/T5L6NbufZ6V8bH8mSHdlRkDjAPWNCFzsKc9ODTHOH/ajwYENbyxhKsfYC7n3koQ==",
       "dev": true
     },
     "@jest/console": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "typescript": "4.x || 5.x"
   },
   "devDependencies": {
+    "@jdeurt/math.ts": "^2.0.0",
     "@types/glob": "^7.2.0",
     "@types/jest": "^28",
     "@types/node": "14.11.2",

--- a/src/helpers/identifiers.ts
+++ b/src/helpers/identifiers.ts
@@ -27,7 +27,7 @@ export function getLibRefName(libName: string) {
     libName = libName.substring(1);
   }
 
-  const parts = libName.split(/[\/\-]/g);
+  const parts = libName.split(/[\/\-\.]/g);
   return parts.map(p => p[0].toUpperCase() + p.substring(1)).join('');
 }
 

--- a/tests/assets/scopedWithPeriod.ts
+++ b/tests/assets/scopedWithPeriod.ts
@@ -1,0 +1,5 @@
+import { Add } from '@jdeurt/math.ts';
+
+export interface MyMath {
+  add: Add<number, number>;
+}


### PR DESCRIPTION
Added support for scoped packages with a period on the right side
Previously if generating declaration for file importing from a scoped package with a period on the right, it would generate an invalid declaration file, with typescript errors, as periods are not allowed in the as alias portion of the import e.g. `import * as test.one.two from '@test/one.two'`
Added Test to ensure no ts errors.